### PR TITLE
Renames project from Nanoservice to Blok

### DIFF
--- a/.github/workflows/prerelease.yml.disabled
+++ b/.github/workflows/prerelease.yml.disabled
@@ -12,7 +12,7 @@ jobs:
   prerelease:
     name: Changesets Prerelease
     # Prevents changesets action from creating a PR on forks
-    if: github.repository == 'deskree-inc/nanoservice-ts'
+    if: github.repository == 'deskree-inc/blok'
     runs-on: ubuntu-latest
     # Permissions necessary for Changesets to push a new branch and open PRs
     # (for automated Version Packages PRs), and request the JWT for provenance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Here’s a set of **Contribution Guidelines** tailored for your open-source proj
 
 # Contribution Guidelines
 
-Thank you for considering contributing to **nanoservice-ts**! We welcome contributions of all types, including bug fixes, feature implementations, documentation improvements, and feedback. These guidelines are here to make the process clear and smooth for everyone.
+Thank you for considering contributing to **Blok**! We welcome contributions of all types, including bug fixes, feature implementations, documentation improvements, and feedback. These guidelines are here to make the process clear and smooth for everyone.
 
 ---
 
@@ -19,8 +19,8 @@ Thank you for considering contributing to **nanoservice-ts**! We welcome contrib
 - Clone the forked repository to your local machine.
 
 ```bash
-git clone https://github.com/YOUR_USERNAME/nanoservice-ts.git
-cd nanoservice-ts
+git clone https://github.com/YOUR_USERNAME/blok.git
+cd blok
 ```
 
 ### 3. **Set Up Your Environment**
@@ -87,4 +87,4 @@ If you have questions or need help, feel free to:
 - Join our [Discord community](https://discord.gg/QXhHzw7azs).
 - Open an issue with the `question` label.
 
-We’re excited to collaborate with you and improve **nanoservice-ts** together!
+We’re excited to collaborate with you and improve **Blok** together!

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 <a id="readme-top"></a>
 
-![GitHub Repo stars](https://img.shields.io/github/stars/deskree-inc/nanoservice-ts)
-![GitHub forks](https://img.shields.io/github/forks/deskree-inc/nanoservice-ts)
-![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/deskree-inc/nanoservice-ts)
-![GitHub License](https://img.shields.io/github/license/deskree-inc/nanoservice-ts)
-![GitHub contributors](https://img.shields.io/github/contributors/deskree-inc/nanoservice-ts)
+![GitHub Repo stars](https://img.shields.io/github/stars/deskree-inc/blok)
+![GitHub forks](https://img.shields.io/github/forks/deskree-inc/blok)
+![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/deskree-inc/blok)
+![GitHub License](https://img.shields.io/github/license/deskree-inc/blok)
+![GitHub contributors](https://img.shields.io/github/contributors/deskree-inc/blok)
 ![Discord](https://img.shields.io/discord/1317176082268426240)
 
 
 <!-- PROJECT LOGO -->
 <br />
 <div align="center">
-  <a href="https://github.com/deskree-inc/nanoservice-ts">
+  <a href="https://github.com/deskree-inc/blok">
     <img src="docs/assets/logo/dark.svg" alt="Logo" height="80">
   </a>
 
@@ -23,9 +23,9 @@
     <a href="https://blok.build/"><strong>Explore the docs »</strong></a>
     <br />
     <br />
-    <a href="https://github.com/deskree-inc/nanoservice-ts/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=">Report Bug</a>
+    <a href="https://github.com/deskree-inc/blok/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=">Report Bug</a>
     ·
-    <a href="https://github.com/deskree-inc/nanoservice-ts/issues/new?assignees=&labels=&projects=&template=feature_request.md&title=">Request Feature</a>
+    <a href="https://github.com/deskree-inc/blok/issues/new?assignees=&labels=&projects=&template=feature_request.md&title=">Request Feature</a>
   </p>
 </div>
 
@@ -144,12 +144,12 @@ To contribute to the Blok documentation, follow these steps:
 
 1. Fork the project
 
-     - Go to the [Blok repository](https://github.com/deskree-inc/nanoservice-ts) and fork it to your GitHub account.
+     - Go to the [Blok repository](https://github.com/deskree-inc/blok) and fork it to your GitHub account.
 
 2. Clone the project to your local machine
 
 ```
-   git clone https://github.com/deskree-inc/nanoservice-ts.git
+   git clone https://github.com/deskree-inc/blok.git
 ```
 3. Navigate to the project directory
 ```
@@ -157,7 +157,7 @@ cd Blok
 ```
 4. Add the upstream remote
 ```
-git remote add upstream https://github.com/deskree-inc/nanoservice-ts.git
+git remote add upstream https://github.com/deskree-inc/blok.git
 ```
 5. Run the application in development mode
 
@@ -200,7 +200,7 @@ X: [@nanoservice_ts](https://x.com/nanoservice_ts)
 
 Reddit: [r/nanoservice](https://www.reddit.com/r/nanoservice/)
 
-Project Link: [https://github.com/deskree-inc/nanoservice-ts](https://github.com/deskree-inc/nanoservice-ts)
+Project Link: [https://github.com/deskree-inc/blok](https://github.com/deskree-inc/blok)
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Here’s a **Security Policy** tailored for your repository:
 
 ## Supported Versions
 
-We actively support the following versions of **nanoservice-ts** with security updates:
+We actively support the following versions of **Blok** with security updates:
 
 | Version | Supported          |
 |---------|--------------------|
@@ -43,7 +43,7 @@ If you discover a security vulnerability, please help us address it responsibly 
 ## Security Best Practices for Users
 
 To ensure the security of your application:
-- Always use the latest stable version of **nanoservice-ts**.
+- Always use the latest stable version of **Blok**.
 - Regularly review your dependencies for vulnerabilities.
 - Report any unexpected behavior or potential vulnerabilities.
 
@@ -51,4 +51,4 @@ To ensure the security of your application:
 
 ## Thank You!
 
-We greatly appreciate your efforts to keep **nanoservice-ts** and its community safe. Your responsible disclosure helps us improve and protect the ecosystem.
+We greatly appreciate your efforts to keep **Blok** and its community safe. Your responsible disclosure helps us improve and protect the ecosystem.

--- a/docs/c/core/runner.mdx
+++ b/docs/c/core/runner.mdx
@@ -18,8 +18,8 @@ In addition, it also tracks important parameters and metrics during the workflow
 
 ### **1. Clone the Repository**  
 ```bash
-git clone https://github.com/deskree-inc/nanoservice-ts.git
-cd nanoservice-ts/core/runner
+git clone https://github.com/deskree-inc/blok.git
+cd blok/core/runner
 npm install
 ```
 
@@ -90,5 +90,5 @@ In the PR description, include:
 ### **Final Notes**
 Contributing to the Runner helps improve the **efficiency and reliability** of `Blok`. If you have any questions, open an issue on GitHub! 🚀  
 
-🔗 [GitHub Repository](https://github.com/deskree-inc/nanoservice-ts.git)  
+🔗 [GitHub Repository](https://github.com/deskree-inc/blok.git)  
 ```

--- a/docs/c/core/shared.mdx
+++ b/docs/c/core/shared.mdx
@@ -18,12 +18,12 @@ The **Shared** module in `Blok` contains common utilities used across the framew
 
 ## **Repository & Setup**  
 The `Blok` framework is hosted at:  
-🔗 [GitHub Repository](https://github.com/deskree-inc/nanoservice-ts.git)  
+🔗 [GitHub Repository](https://github.com/deskree-inc/blok.git)  
 
 ### Clone the Repository**  
 ```bash
-git clone https://github.com/deskree-inc/nanoservice-ts.git
-cd nanoservice-ts/core/shared
+git clone https://github.com/deskree-inc/blok.git
+cd blok/core/shared
 npm install
 ```
 
@@ -75,5 +75,5 @@ In the PR description, include:
 ## **Final Notes**
 Contributing to **Shared** ensures that all components of `Blok` (Runner, Nodes, and Triggers) function smoothly and consistently. If you have any questions, **open an issue or PR** on GitHub! 🚀  
 
-🔗 [GitHub Repository](https://github.com/deskree-inc/nanoservice-ts.git)  
+🔗 [GitHub Repository](https://github.com/deskree-inc/blok.git)  
 ```

--- a/docs/c/extensions/cli.mdx
+++ b/docs/c/extensions/cli.mdx
@@ -19,7 +19,7 @@ The CLI (`@nanoservice-ts/cli`) is a core tool for managing workflows, nodes, an
 ### **1. Setup the Development Environment**  
 Clone the repository and navigate to the CLI package:  
 ```bash
-git clone https://github.com/deskree-inc/nanoservice-ts.git
+git clone https://github.com/deskree-inc/blok.git
 cd packages/cli
 npm install
 ```

--- a/docs/c/extensions/nodes.mdx
+++ b/docs/c/extensions/nodes.mdx
@@ -25,7 +25,7 @@ Nodes are stored in the `/nodes` directory and can be reused across multiple wor
 ## **Getting Started**
 Clone the repository and navigate to the `nodes` directory:  
 ```bash
-git clone https://github.com/deskree-inc/nanoservice-ts.git
+git clone https://github.com/deskree-inc/blok.git
 cd nodes
 ```
 

--- a/docs/c/extensions/triggers.mdx
+++ b/docs/c/extensions/triggers.mdx
@@ -25,7 +25,7 @@ Triggers are stored in the `/triggers` directory and are configurable via CLI.
 
 Clone the repository and navigate to the `triggers` directory:  
 ```bash
-git clone https://github.com/deskree-inc/nanoservice-ts.git
+git clone https://github.com/deskree-inc/blok.git
 cd triggers
 npm install
 ```
@@ -67,5 +67,5 @@ npm install
 ---
 
 ## **Final Notes**
-Triggers are a **key part of automation in nanoservice-ts**. By contributing new triggers, you help expand the framework’s capabilities and enable more use cases. If you have any questions, open an issue or join the discussion! 🚀  
+Triggers are a **key part of automation in Blok**. By contributing new triggers, you help expand the framework’s capabilities and enable more use cases. If you have any questions, open an issue or join the discussion! 🚀  
 ```

--- a/docs/c/overview/how-to-contribute.mdx
+++ b/docs/c/overview/how-to-contribute.mdx
@@ -29,8 +29,8 @@ To set up the development environment, follow the steps below:
 <Steps>
   <Step title="Close the repository">
     ```bash
-    git clone https://github.com/deskree-inc/nanoservice-ts.git
-    cd nanoservice-ts
+    git clone https://github.com/deskree-inc/blok.git
+    cd blok
     ```
   </Step>
   <Step title="Install the dependencies">

--- a/docs/d/cli/build.mdx
+++ b/docs/d/cli/build.mdx
@@ -2,11 +2,11 @@
 title: Build
 ---
 
-The `nanoctl build` command compiles your nanoservice source code into a deployable artifact, preparing it for execution or deployment. This step ensures your code, dependencies, and configuration are packaged correctly according to the `Blok` project structure.
+The `nanoctl build` command compiles your Blok source code into a deployable artifact, preparing it for execution or deployment. This step ensures your code, dependencies, and configuration are packaged correctly according to the `Blok` project structure.
 
 Whether you're building from the default project directory, a custom location, or directly within the current folder, the CLI offers flexible options to match your development workflow. Use it as part of your standard development, testing, or deployment process.
 
-Once the build is complete, you're ready to deploy your nanoservice using the [`deploy`](./Deployment.md) command.
+Once the build is complete, you're ready to deploy your Blok using the [`deploy`](./Deployment.md) command.
 
 ## Build Blok 
 
@@ -14,12 +14,12 @@ Once the build is complete, you're ready to deploy your nanoservice using the [`
 ```bash
 npx nanoctl build [options]
 ```
-  Compiles and packages a nanoservice from source code into a deployable artifact.
+  Compiles and packages a Blok from source code into a deployable artifact.
  
   ### Options
   | Option       | Alias | Type    | Description                | Default            |
   |--------------|-------|---------|----------------------------|--------------------|
-  | `--directory`| `-d`  | string  | Source directory path      | `./nanoservice-ts` |
+  | `--directory`| `-d`  | string  | Source directory path      | `./blok` |
   | `--help`     | `-h`  | boolean | Show help                  | `false`            |
  
   ### Commands
@@ -34,7 +34,7 @@ npx nanoctl build [options]
   ```
   #### Build in specific directory:
   ```bash
-  npx nanoctl build -d ./my-nanoservice
+  npx nanoctl build -d ./my-blok
   ```
 
   #### Build in current directory:

--- a/docs/d/cli/nodes.mdx
+++ b/docs/d/cli/nodes.mdx
@@ -2,11 +2,11 @@
 title: Node
 ---
 
-**Nodes** are the core building blocks of your **nanoservice-ts** applications, encapsulating specific pieces of logic. The `nanoctl` CLI provides commands to help you create and manage these Nodes efficiently, primarily through the `create node` command.
+**Nodes** are the core building blocks of your **Blok** applications, encapsulating specific pieces of logic. The `nanoctl` CLI provides commands to help you create and manage these Nodes efficiently, primarily through the `create node` command.
 
 ## `create node`
 
-This command is used to scaffold a new Node within your **nanoservice-ts** project.
+This command is used to scaffold a new Node within your **Blok** project.
 
 > <sub>**Purpose**: To generate the boilerplate files for a new Node, including its definition (`node.json`) and implementation file (e.g., `index.ts`), placing them in the appropriate directory within your project (usually `nodes/`).</sub>
 

--- a/docs/d/cli/overview.mdx
+++ b/docs/d/cli/overview.mdx
@@ -2,20 +2,20 @@
 title: Overview
 ---
 
-The **nanoservice-ts** Command Line Interface (CLI), `nanoctl`, is an essential tool for developing, managing, and deploying your **nanoservice-ts** applications. It provides a set of commands to streamline common tasks, from project scaffolding to Node and Workflow creation.
+The **Blok** Command Line Interface (CLI), `nanoctl`, is an essential tool for developing, managing, and deploying your **Blok** applications. It provides a set of commands to streamline common tasks, from project scaffolding to Node and Workflow creation.
 
 ## What is `nanoctl`?
 
-`nanoctl` is designed to enhance developer productivity by automating repetitive tasks and providing a consistent interface for interacting with the **nanoservice-ts** framework.
+`nanoctl` is designed to enhance developer productivity by automating repetitive tasks and providing a consistent interface for interacting with the **Blok** framework.
 
 Key functionalities typically include:
 
-*   **Project Initialization**: Creating new **nanoservice-ts** projects with a standard directory structure and boilerplate code.
+*   **Project Initialization**: Creating new **Blok** projects with a standard directory structure and boilerplate code.
 *   **Code Generation (Scaffolding)**: Generating new Nodes, Workflows, and potentially other components with basic templates.
 *   **Development Server**: Running a local development server to test your workflows.
 *   **Building & Packaging**: Preparing your application for deployment.
-*   **Deployment Commands**: Assisting with deploying your **nanoservice-ts** applications to various environments (though this might also involve other platform-specific tools).
-*   **Authentication/Login**: Commands to authenticate with **nanoservice-ts** services or platforms (e.g., Deskree).
+*   **Deployment Commands**: Assisting with deploying your **Blok** applications to various environments (though this might also involve other platform-specific tools).
+*   **Authentication/Login**: Commands to authenticate with **Blok** services or platforms (e.g., Deskree).
 
 ## Installation / Usage
 
@@ -25,19 +25,19 @@ As mentioned in the [First Steps](../introduction/first-steps.mdx) guide, you ca
 npx nanoctl@latest <command>
 ```
 
-Refer to the official **nanoservice-ts** installation instructions for the recommended approach.
+Refer to the official **Blok** installation instructions for the recommended approach.
 
 ## Common Command Categories
 
 This section of the documentation will cover the main commands provided by `nanoctl`, grouped by their purpose:
 
-*   **[Project Management](./project.mdx)**: Commands related to creating and managing **nanoservice-ts** projects.
+*   **[Project Management](./project.mdx)**: Commands related to creating and managing **Blok** projects.
     *   `npx nanoctl@latest create project`
 *   **[Node Management](./nodes.mdx)**: Commands for scaffolding and managing Nodes.
     *   `npx nanoctl@latest create node`
 *   **[Workflow Management](./workflows.mdx)**: Commands for scaffolding and managing Workflows.
     *   `npx nanoctl@latest create workflow`
-*   **[Authentication](./login.mdx)**: Commands for logging into **nanoservice-ts** platforms or services.
+*   **[Authentication](./login.mdx)**: Commands for logging into **Blok** platforms or services.
     *   `npx nanoctl@latest login` or `npx nanoctl@latest logout`
 *   **[Build Process](./build.mdx)**: Commands related to building your application for production.
     *   `npx nanoctl@latest build`

--- a/docs/d/cli/project.mdx
+++ b/docs/d/cli/project.mdx
@@ -2,13 +2,13 @@
 title: Project
 ---
 
-Managing **nanoservice-ts** projects effectively starts with the `nanoctl` CLI. This section focuses on commands related to project creation and overall project lifecycle management, primarily the `create project` command.
+Managing **Blok** projects effectively starts with the `nanoctl` CLI. This section focuses on commands related to project creation and overall project lifecycle management, primarily the `create project` command.
 
 ## `create project`
 
-This is typically the first `nanoctl` command you will use when starting a new **nanoservice-ts** application.
+This is typically the first `nanoctl` command you will use when starting a new **Blok** application.
 
-> <sub>**Purpose**: To scaffold a new **nanoservice-ts** project with a predefined directory structure, necessary configuration files, and optional templates.</sub>
+> <sub>**Purpose**: To scaffold a new **Blok** project with a predefined directory structure, necessary configuration files, and optional templates.</sub>
 
 **Usage**:
 
@@ -35,7 +35,7 @@ When you run `npx nanoctl@latest create project`, the CLI will typically guide y
 Upon completion, the `npx nanoctl@latest create project` command will:
 
 1.  Create a new directory with your desired project name, or use the current directory instead.
-2.  Populate this directory with the standard **nanoservice-ts** project structure based on the chosen template. This typically includes:
+2.  Populate this directory with the standard **Blok** project structure based on the chosen template. This typically includes:
     *   `src/` directory containing the project's source code. 
     *   `src/nodes/` directory for your custom Nodes.
     *   `src/nodes.ts` class used to register your custom nodes or modules.

--- a/docs/d/fundamentals/architecture-comparison.mdx
+++ b/docs/d/fundamentals/architecture-comparison.mdx
@@ -14,7 +14,7 @@ Blok vs Micro vs Monolith Architecture comparison.
   Microservices architecture splits applications into smaller, independently deployable services. Each microservice focuses on a specific function and communicates via APIs.
 
 - **Nanoservices**  
-  Nanoservices break microservices into even smaller, isolated, and lightweight functional units that execute single tasks. They can be deployed using **runners** like the **nanoservice-ts** framework or more advanced platforms like Atomic Computing.
+  Nanoservices break microservices into even smaller, isolated, and lightweight functional units that execute single tasks. They can be deployed using **runners** like the **Blok** framework or more advanced platforms like Atomic Computing.
 
 ---
 
@@ -34,7 +34,7 @@ Blok vs Micro vs Monolith Architecture comparison.
 ## **3. Deployment: Nanoservices' Unique Advantage**
 
 ### **Open Source Deployment**
-Using **nanoservice-ts** (an open-source framework like Express.js), developers can deploy nanoservice projects **locally or in production** as they would a monolithic project or as microservices.
+Using **Blok** (an open-source framework like Express.js), developers can deploy nanoservice projects **locally or in production** as they would a monolithic project or as microservices.
 
 - **Monolith-Style Deployment:**  
   - A single project contains multiple workflows and bloks within folders.  
@@ -53,7 +53,7 @@ With **Atomic Computing**, deployment is transformed into an advanced, scalable,
 - **AI-Driven Scaling:** Automatically scales workloads to meet traffic demands, ensuring high performance and zero resource waste.  
 - **Marketplace Access:** Seamless integration of reusable bloks and workflows available on Atomic Market.  
 - **Built-In Observability:** Real-time metrics, logging, and intelligent monitoring for debugging and performance optimization.  
-- **Consistency in Development:** The same **nanoservice-ts** development experience is maintained, allowing easy migration from open-source projects to enterprise-level scaling.
+- **Consistency in Development:** The same **Blok** development experience is maintained, allowing easy migration from open-source projects to enterprise-level scaling.
 
 This dual deployment model offers unmatched flexibility:  
 - **Learn and Innovate** with open-source nanoservice-ts.  
@@ -95,6 +95,6 @@ This dual deployment model offers unmatched flexibility:
 
 **Nanoservices** offer a modern, highly modular approach to backend development, combining the simplicity of monolithic deployment with the flexibility and scalability of microservices.  
 
-With **nanoservice-ts**, developers can quickly adopt and learn bloks using familiar tools and workflows. As projects grow and enterprise needs emerge, **Atomic Computing** provides an advanced execution environment powered by AI, observability, and marketplace integrations.
+With **Blok**, developers can quickly adopt and learn bloks using familiar tools and workflows. As projects grow and enterprise needs emerge, **Atomic Computing** provides an advanced execution environment powered by AI, observability, and marketplace integrations.
 
 The key advantage of bloks lies in their ability to scale granularly while maintaining a unified development experience, ensuring a smooth transition from open-source experimentation to enterprise-grade performance.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -96,7 +96,7 @@
 			},
 			{
 				"tab": "Changelog",
-				"href": "https://github.com/deskree-inc/nanoservice-ts/releases"
+				"href": "https://github.com/deskree-inc/blok/releases"
 			},
 			{
 				"tab": "Roadmap",
@@ -144,7 +144,7 @@
 		],
 		"primary": {
 			"type": "github",
-			"href": "https://github.com/deskree-inc/nanoservice-ts"
+			"href": "https://github.com/deskree-inc/blok"
 		}
 	},
 	"footer": {

--- a/docs/o/support/index.mdx
+++ b/docs/o/support/index.mdx
@@ -8,9 +8,9 @@ We appreciate your interest in Blok ! Your support helps us grow and improve the
 
 ## How You Can Support
 
-*   **Contribute to the Project**: We welcome contributions to the Blok codebase, documentation, or examples. Check out our [Contributing Guide](https://github.com/deskree-inc/nanoservice-ts/blob/main/CONTRIBUTING.md) (link to be confirmed or created in the repository) for more details.
+*   **Contribute to the Project**: We welcome contributions to the Blok codebase, documentation, or examples. Check out our [Contributing Guide](https://github.com/deskree-inc/blok/blob/main/CONTRIBUTING.md) (link to be confirmed or created in the repository) for more details.
 *   **Report Issues & Request Features**: If you encounter any bugs, have suggestions for improvements, or would like to request new features, please open an issue on our GitHub repository.
-    *   **[Submit an Issue on GitHub](https://github.com/deskree-inc/nanoservice-ts/issues)**
+    *   **[Submit an Issue on GitHub](https://github.com/deskree-inc/blok/issues)**
 *   **Spread the Word**: Tell your friends, colleagues, and the developer community about Blok .
 *   **Share Your Projects**: If you build something cool with Blok , let us know! We love to see how the community is using the framework.
 

--- a/docs/ref/classes/runner_src.Configuration.md
+++ b/docs/ref/classes/runner_src.Configuration.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / Configuration
+[blok - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / Configuration
 
 # Class: Configuration
 
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:27](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L27)
+[core/runner/src/Configuration.ts:27](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L27)
 
 ## Properties
 
@@ -59,7 +59,7 @@
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:25](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L25)
+[core/runner/src/Configuration.ts:25](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L25)
 
 ___
 
@@ -73,7 +73,7 @@ Config.name
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:19](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L19)
+[core/runner/src/Configuration.ts:19](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L19)
 
 ___
 
@@ -87,7 +87,7 @@ Config.nodes
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:22](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L22)
+[core/runner/src/Configuration.ts:22](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L22)
 
 ___
 
@@ -101,7 +101,7 @@ Config.steps
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:21](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L21)
+[core/runner/src/Configuration.ts:21](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L21)
 
 ___
 
@@ -115,7 +115,7 @@ Config.trigger
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:23](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L23)
+[core/runner/src/Configuration.ts:23](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L23)
 
 ___
 
@@ -129,7 +129,7 @@ Config.version
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:20](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L20)
+[core/runner/src/Configuration.ts:20](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L20)
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:18](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L18)
+[core/runner/src/Configuration.ts:18](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L18)
 
 ___
 
@@ -149,7 +149,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:24](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L24)
+[core/runner/src/Configuration.ts:24](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L24)
 
 ## Methods
 
@@ -169,7 +169,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:147](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L147)
+[core/runner/src/Configuration.ts:147](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L147)
 
 ___
 
@@ -189,7 +189,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:84](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L84)
+[core/runner/src/Configuration.ts:84](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L84)
 
 ___
 
@@ -209,7 +209,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:57](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L57)
+[core/runner/src/Configuration.ts:57](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L57)
 
 ___
 
@@ -230,7 +230,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:35](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L35)
+[core/runner/src/Configuration.ts:35](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L35)
 
 ___
 
@@ -250,7 +250,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:219](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L219)
+[core/runner/src/Configuration.ts:219](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L219)
 
 ___
 
@@ -271,7 +271,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:208](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L208)
+[core/runner/src/Configuration.ts:208](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L208)
 
 ___
 
@@ -291,7 +291,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:169](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L169)
+[core/runner/src/Configuration.ts:169](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L169)
 
 ___
 
@@ -305,7 +305,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:178](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L178)
+[core/runner/src/Configuration.ts:178](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L178)
 
 ___
 
@@ -325,4 +325,4 @@ ___
 
 #### Defined in
 
-[core/runner/src/Configuration.ts:192](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Configuration.ts#L192)
+[core/runner/src/Configuration.ts:192](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Configuration.ts#L192)

--- a/docs/ref/classes/runner_src.ConfigurationResolver.md
+++ b/docs/ref/classes/runner_src.ConfigurationResolver.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / ConfigurationResolver
+[blok - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / ConfigurationResolver
 
 # Class: ConfigurationResolver
 
@@ -37,7 +37,7 @@
 
 #### Defined in
 
-[core/runner/src/ConfigurationResolver.ts:9](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/ConfigurationResolver.ts#L9)
+[core/runner/src/ConfigurationResolver.ts:9](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/ConfigurationResolver.ts#L9)
 
 ## Properties
 
@@ -47,7 +47,7 @@
 
 #### Defined in
 
-[core/runner/src/ConfigurationResolver.ts:7](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/ConfigurationResolver.ts#L7)
+[core/runner/src/ConfigurationResolver.ts:7](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/ConfigurationResolver.ts#L7)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/ConfigurationResolver.ts:6](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/ConfigurationResolver.ts#L6)
+[core/runner/src/ConfigurationResolver.ts:6](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/ConfigurationResolver.ts#L6)
 
 ## Methods
 
@@ -78,4 +78,4 @@ ___
 
 #### Defined in
 
-[core/runner/src/ConfigurationResolver.ts:17](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/ConfigurationResolver.ts#L17)
+[core/runner/src/ConfigurationResolver.ts:17](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/ConfigurationResolver.ts#L17)

--- a/docs/ref/classes/runner_src.DefaultLogger.md
+++ b/docs/ref/classes/runner_src.DefaultLogger.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / DefaultLogger
+[blok - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / DefaultLogger
 
 # Class: DefaultLogger
 
@@ -61,7 +61,7 @@ GlobalLogger.constructor
 
 #### Defined in
 
-[core/runner/src/DefaultLogger.ts:41](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/DefaultLogger.ts#L41)
+[core/runner/src/DefaultLogger.ts:41](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/DefaultLogger.ts#L41)
 
 ## Properties
 
@@ -73,7 +73,7 @@ The name of the application.
 
 #### Defined in
 
-[core/runner/src/DefaultLogger.ts:32](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/DefaultLogger.ts#L32)
+[core/runner/src/DefaultLogger.ts:32](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/DefaultLogger.ts#L32)
 
 ___
 
@@ -85,7 +85,7 @@ The environment in which the application is running.
 
 #### Defined in
 
-[core/runner/src/DefaultLogger.ts:27](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/DefaultLogger.ts#L27)
+[core/runner/src/DefaultLogger.ts:27](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/DefaultLogger.ts#L27)
 
 ___
 
@@ -97,7 +97,7 @@ The ID of the request.
 
 #### Defined in
 
-[core/runner/src/DefaultLogger.ts:22](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/DefaultLogger.ts#L22)
+[core/runner/src/DefaultLogger.ts:22](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/DefaultLogger.ts#L22)
 
 ___
 
@@ -109,7 +109,7 @@ The name of the workflow.
 
 #### Defined in
 
-[core/runner/src/DefaultLogger.ts:12](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/DefaultLogger.ts#L12)
+[core/runner/src/DefaultLogger.ts:12](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/DefaultLogger.ts#L12)
 
 ___
 
@@ -121,7 +121,7 @@ The path of the workflow.
 
 #### Defined in
 
-[core/runner/src/DefaultLogger.ts:17](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/DefaultLogger.ts#L17)
+[core/runner/src/DefaultLogger.ts:17](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/DefaultLogger.ts#L17)
 
 ## Methods
 
@@ -144,7 +144,7 @@ Logs an error message to the console with metadata.
 
 #### Defined in
 
-[core/runner/src/DefaultLogger.ts:77](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/DefaultLogger.ts#L77)
+[core/runner/src/DefaultLogger.ts:77](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/DefaultLogger.ts#L77)
 
 ___
 
@@ -170,7 +170,7 @@ The message with injected metadata.
 
 #### Defined in
 
-[core/runner/src/DefaultLogger.ts:90](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/DefaultLogger.ts#L90)
+[core/runner/src/DefaultLogger.ts:90](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/DefaultLogger.ts#L90)
 
 ___
 
@@ -192,7 +192,7 @@ Logs a message to the console with metadata.
 
 #### Defined in
 
-[core/runner/src/DefaultLogger.ts:55](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/DefaultLogger.ts#L55)
+[core/runner/src/DefaultLogger.ts:55](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/DefaultLogger.ts#L55)
 
 ___
 
@@ -215,4 +215,4 @@ Logs a message to the console with a specified log level and metadata.
 
 #### Defined in
 
-[core/runner/src/DefaultLogger.ts:66](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/DefaultLogger.ts#L66)
+[core/runner/src/DefaultLogger.ts:66](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/DefaultLogger.ts#L66)

--- a/docs/ref/classes/runner_src.LocalStorage.md
+++ b/docs/ref/classes/runner_src.LocalStorage.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / LocalStorage
+[blok - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / LocalStorage
 
 # Class: LocalStorage
 
@@ -47,7 +47,7 @@
 
 #### Defined in
 
-[core/runner/src/LocalStorage.ts:11](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/LocalStorage.ts#L11)
+[core/runner/src/LocalStorage.ts:11](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/LocalStorage.ts#L11)
 
 ## Methods
 
@@ -71,7 +71,7 @@
 
 #### Defined in
 
-[core/runner/src/ResolverBase.ts:9](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/ResolverBase.ts#L9)
+[core/runner/src/ResolverBase.ts:9](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/ResolverBase.ts#L9)
 
 ___
 
@@ -97,4 +97,4 @@ ___
 
 #### Defined in
 
-[core/runner/src/LocalStorage.ts:13](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/LocalStorage.ts#L13)
+[core/runner/src/LocalStorage.ts:13](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/LocalStorage.ts#L13)

--- a/docs/ref/classes/runner_src.NanoService.md
+++ b/docs/ref/classes/runner_src.NanoService.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / NanoService
+[blok - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / NanoService
 
 # Class: NanoService\<T\>
 
@@ -58,7 +58,7 @@ NodeBase.constructor
 
 #### Defined in
 
-[core/runner/src/NanoService.ts:17](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoService.ts#L17)
+[core/runner/src/NanoService.ts:17](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoService.ts#L17)
 
 ## Properties
 
@@ -68,7 +68,7 @@ NodeBase.constructor
 
 #### Defined in
 
-[core/runner/src/NanoService.ts:13](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoService.ts#L13)
+[core/runner/src/NanoService.ts:13](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoService.ts#L13)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/NanoService.ts:14](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoService.ts#L14)
+[core/runner/src/NanoService.ts:14](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoService.ts#L14)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/NanoService.ts:15](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoService.ts#L15)
+[core/runner/src/NanoService.ts:15](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoService.ts#L15)
 
 ## Methods
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/NanoService.ts:29](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoService.ts#L29)
+[core/runner/src/NanoService.ts:29](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoService.ts#L29)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/NanoService.ts:99](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoService.ts#L99)
+[core/runner/src/NanoService.ts:99](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoService.ts#L99)
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/NanoService.ts:36](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoService.ts#L36)
+[core/runner/src/NanoService.ts:36](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoService.ts#L36)
 
 ___
 
@@ -169,7 +169,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/NanoService.ts:24](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoService.ts#L24)
+[core/runner/src/NanoService.ts:24](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoService.ts#L24)
 
 ___
 
@@ -190,4 +190,4 @@ ___
 
 #### Defined in
 
-[core/runner/src/NanoService.ts:104](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoService.ts#L104)
+[core/runner/src/NanoService.ts:104](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoService.ts#L104)

--- a/docs/ref/classes/runner_src.NanoServiceResponse.md
+++ b/docs/ref/classes/runner_src.NanoServiceResponse.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / NanoServiceResponse
+[blok - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / NanoServiceResponse
 
 # Class: NanoServiceResponse
 
@@ -40,7 +40,7 @@
 
 #### Defined in
 
-[core/runner/src/NanoServiceResponse.ts:15](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L15)
+[core/runner/src/NanoServiceResponse.ts:15](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L15)
 
 ## Properties
 
@@ -50,7 +50,7 @@
 
 #### Defined in
 
-[core/runner/src/NanoServiceResponse.ts:13](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L13)
+[core/runner/src/NanoServiceResponse.ts:13](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L13)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/NanoServiceResponse.ts:10](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L10)
+[core/runner/src/NanoServiceResponse.ts:10](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L10)
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/NanoServiceResponse.ts:11](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L11)
+[core/runner/src/NanoServiceResponse.ts:11](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L11)
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/NanoServiceResponse.ts:9](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L9)
+[core/runner/src/NanoServiceResponse.ts:9](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L9)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/NanoServiceResponse.ts:12](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L12)
+[core/runner/src/NanoServiceResponse.ts:12](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L12)
 
 ## Methods
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/NanoServiceResponse.ts:23](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L23)
+[core/runner/src/NanoServiceResponse.ts:23](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L23)
 
 ___
 
@@ -134,7 +134,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/NanoServiceResponse.ts:35](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L35)
+[core/runner/src/NanoServiceResponse.ts:35](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L35)
 
 ___
 
@@ -154,4 +154,4 @@ ___
 
 #### Defined in
 
-[core/runner/src/NanoServiceResponse.ts:29](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L29)
+[core/runner/src/NanoServiceResponse.ts:29](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L29)

--- a/docs/ref/classes/runner_src.NodeMap.md
+++ b/docs/ref/classes/runner_src.NodeMap.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / NodeMap
+[blok - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / NodeMap
 
 # Class: NodeMap
 
@@ -38,7 +38,7 @@
 
 #### Defined in
 
-[core/runner/src/NodeMap.ts:4](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NodeMap.ts#L4)
+[core/runner/src/NodeMap.ts:4](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NodeMap.ts#L4)
 
 ## Methods
 
@@ -59,7 +59,7 @@
 
 #### Defined in
 
-[core/runner/src/NodeMap.ts:6](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NodeMap.ts#L6)
+[core/runner/src/NodeMap.ts:6](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NodeMap.ts#L6)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/NodeMap.ts:10](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NodeMap.ts#L10)
+[core/runner/src/NodeMap.ts:10](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NodeMap.ts#L10)
 
 ___
 
@@ -93,4 +93,4 @@ ___
 
 #### Defined in
 
-[core/runner/src/NodeMap.ts:14](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NodeMap.ts#L14)
+[core/runner/src/NodeMap.ts:14](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NodeMap.ts#L14)

--- a/docs/ref/classes/runner_src.ResolverBase.md
+++ b/docs/ref/classes/runner_src.ResolverBase.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / ResolverBase
+[blok - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / ResolverBase
 
 # Class: ResolverBase
 
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[core/runner/src/ResolverBase.ts:9](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/ResolverBase.ts#L9)
+[core/runner/src/ResolverBase.ts:9](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/ResolverBase.ts#L9)
 
 ___
 
@@ -70,4 +70,4 @@ ___
 
 #### Defined in
 
-[core/runner/src/ResolverBase.ts:7](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/ResolverBase.ts#L7)
+[core/runner/src/ResolverBase.ts:7](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/ResolverBase.ts#L7)

--- a/docs/ref/classes/runner_src.Runner.md
+++ b/docs/ref/classes/runner_src.Runner.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / Runner
+[blok - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / Runner
 
 # Class: Runner
 
@@ -51,7 +51,7 @@ Constructs a new Runner instance.
 
 #### Defined in
 
-[core/runner/src/Runner.ts:15](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Runner.ts#L15)
+[core/runner/src/Runner.ts:15](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Runner.ts#L15)
 
 ## Properties
 
@@ -61,7 +61,7 @@ Constructs a new Runner instance.
 
 #### Defined in
 
-[core/runner/src/Runner.ts:8](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Runner.ts#L8)
+[core/runner/src/Runner.ts:8](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Runner.ts#L8)
 
 ## Methods
 
@@ -85,7 +85,7 @@ A promise that resolves to the final context after all steps have been executed.
 
 #### Defined in
 
-[core/runner/src/Runner.ts:26](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/Runner.ts#L26)
+[core/runner/src/Runner.ts:26](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/Runner.ts#L26)
 
 ___
 
@@ -120,4 +120,4 @@ Throws a GlobalError if any step results in an error.
 
 #### Defined in
 
-[core/runner/src/RunnerSteps.ts:15](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/RunnerSteps.ts#L15)
+[core/runner/src/RunnerSteps.ts:15](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/RunnerSteps.ts#L15)

--- a/docs/ref/classes/runner_src.RunnerSteps.md
+++ b/docs/ref/classes/runner_src.RunnerSteps.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / RunnerSteps
+[blok - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / RunnerSteps
 
 # Class: RunnerSteps
 
@@ -59,4 +59,4 @@ Throws a GlobalError if any step results in an error.
 
 #### Defined in
 
-[core/runner/src/RunnerSteps.ts:15](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/RunnerSteps.ts#L15)
+[core/runner/src/RunnerSteps.ts:15](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/RunnerSteps.ts#L15)

--- a/docs/ref/classes/runner_src.TriggerBase.md
+++ b/docs/ref/classes/runner_src.TriggerBase.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / TriggerBase
+[blok - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / TriggerBase
 
 # Class: TriggerBase
 
@@ -46,7 +46,7 @@ Trigger.constructor
 
 #### Defined in
 
-[core/runner/src/TriggerBase.ts:12](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/TriggerBase.ts#L12)
+[core/runner/src/TriggerBase.ts:12](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/TriggerBase.ts#L12)
 
 ## Properties
 
@@ -56,7 +56,7 @@ Trigger.constructor
 
 #### Defined in
 
-[core/runner/src/TriggerBase.ts:10](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/TriggerBase.ts#L10)
+[core/runner/src/TriggerBase.ts:10](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/TriggerBase.ts#L10)
 
 ## Methods
 
@@ -78,7 +78,7 @@ Trigger.constructor
 
 #### Defined in
 
-[core/runner/src/TriggerBase.ts:90](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/TriggerBase.ts#L90)
+[core/runner/src/TriggerBase.ts:90](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/TriggerBase.ts#L90)
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/TriggerBase.ts:122](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/TriggerBase.ts#L122)
+[core/runner/src/TriggerBase.ts:122](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/TriggerBase.ts#L122)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/TriggerBase.ts:19](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/TriggerBase.ts#L19)
+[core/runner/src/TriggerBase.ts:19](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/TriggerBase.ts#L19)
 
 ___
 
@@ -126,7 +126,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/TriggerBase.ts:23](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/TriggerBase.ts#L23)
+[core/runner/src/TriggerBase.ts:23](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/TriggerBase.ts#L23)
 
 ___
 
@@ -140,7 +140,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/TriggerBase.ts:17](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/TriggerBase.ts#L17)
+[core/runner/src/TriggerBase.ts:17](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/TriggerBase.ts#L17)
 
 ___
 
@@ -160,7 +160,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/TriggerBase.ts:27](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/TriggerBase.ts#L27)
+[core/runner/src/TriggerBase.ts:27](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/TriggerBase.ts#L27)
 
 ___
 
@@ -174,4 +174,4 @@ ___
 
 #### Defined in
 
-[core/runner/src/TriggerBase.ts:118](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/TriggerBase.ts#L118)
+[core/runner/src/TriggerBase.ts:118](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/TriggerBase.ts#L118)

--- a/docs/ref/classes/shared_src.GlobalError.md
+++ b/docs/ref/classes/shared_src.GlobalError.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [shared/src](../modules/shared_src.md) / GlobalError
+[blok - v0.1.0](../README.md) / [shared/src](../modules/shared_src.md) / GlobalError
 
 # Class: GlobalError
 
@@ -57,7 +57,7 @@ Error.constructor
 
 #### Defined in
 
-[core/shared/src/GlobalError.ts:7](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/GlobalError.ts#L7)
+[core/shared/src/GlobalError.ts:7](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/GlobalError.ts#L7)
 
 ## Properties
 
@@ -67,7 +67,7 @@ Error.constructor
 
 #### Defined in
 
-[core/shared/src/GlobalError.ts:5](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/GlobalError.ts#L5)
+[core/shared/src/GlobalError.ts:5](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/GlobalError.ts#L5)
 
 ___
 
@@ -184,7 +184,7 @@ node_modules/.pnpm/@types+node@22.13.14/node_modules/@types/node/globals.d.ts:14
 
 #### Defined in
 
-[core/shared/src/GlobalError.ts:27](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/GlobalError.ts#L27)
+[core/shared/src/GlobalError.ts:27](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/GlobalError.ts#L27)
 
 ___
 
@@ -204,7 +204,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/GlobalError.ts:14](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/GlobalError.ts#L14)
+[core/shared/src/GlobalError.ts:14](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/GlobalError.ts#L14)
 
 ___
 
@@ -224,7 +224,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/GlobalError.ts:17](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/GlobalError.ts#L17)
+[core/shared/src/GlobalError.ts:17](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/GlobalError.ts#L17)
 
 ___
 
@@ -244,7 +244,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/GlobalError.ts:23](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/GlobalError.ts#L23)
+[core/shared/src/GlobalError.ts:23](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/GlobalError.ts#L23)
 
 ___
 
@@ -264,7 +264,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/GlobalError.ts:20](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/GlobalError.ts#L20)
+[core/shared/src/GlobalError.ts:20](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/GlobalError.ts#L20)
 
 ___
 
@@ -278,7 +278,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/GlobalError.ts:31](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/GlobalError.ts#L31)
+[core/shared/src/GlobalError.ts:31](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/GlobalError.ts#L31)
 
 ___
 

--- a/docs/ref/classes/shared_src.GlobalLogger.md
+++ b/docs/ref/classes/shared_src.GlobalLogger.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [shared/src](../modules/shared_src.md) / GlobalLogger
+[blok - v0.1.0](../README.md) / [shared/src](../modules/shared_src.md) / GlobalLogger
 
 # Class: GlobalLogger
 
@@ -39,7 +39,7 @@
 
 #### Defined in
 
-[core/shared/src/GlobalLogger.ts:6](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/GlobalLogger.ts#L6)
+[core/shared/src/GlobalLogger.ts:6](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/GlobalLogger.ts#L6)
 
 ## Properties
 
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[core/shared/src/GlobalLogger.ts:4](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/GlobalLogger.ts#L4)
+[core/shared/src/GlobalLogger.ts:4](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/GlobalLogger.ts#L4)
 
 ## Methods
 
@@ -74,7 +74,7 @@ LoggerContext.error
 
 #### Defined in
 
-[core/shared/src/GlobalLogger.ts:12](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/GlobalLogger.ts#L12)
+[core/shared/src/GlobalLogger.ts:12](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/GlobalLogger.ts#L12)
 
 ___
 
@@ -92,7 +92,7 @@ LoggerContext.getLogs
 
 #### Defined in
 
-[core/shared/src/GlobalLogger.ts:14](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/GlobalLogger.ts#L14)
+[core/shared/src/GlobalLogger.ts:14](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/GlobalLogger.ts#L14)
 
 ___
 
@@ -110,7 +110,7 @@ LoggerContext.getLogsAsBase64
 
 #### Defined in
 
-[core/shared/src/GlobalLogger.ts:22](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/GlobalLogger.ts#L22)
+[core/shared/src/GlobalLogger.ts:22](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/GlobalLogger.ts#L22)
 
 ___
 
@@ -128,7 +128,7 @@ LoggerContext.getLogsAsText
 
 #### Defined in
 
-[core/shared/src/GlobalLogger.ts:18](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/GlobalLogger.ts#L18)
+[core/shared/src/GlobalLogger.ts:18](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/GlobalLogger.ts#L18)
 
 ___
 
@@ -152,7 +152,7 @@ LoggerContext.log
 
 #### Defined in
 
-[core/shared/src/GlobalLogger.ts:10](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/GlobalLogger.ts#L10)
+[core/shared/src/GlobalLogger.ts:10](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/GlobalLogger.ts#L10)
 
 ___
 
@@ -177,4 +177,4 @@ LoggerContext.logLevel
 
 #### Defined in
 
-[core/shared/src/GlobalLogger.ts:11](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/GlobalLogger.ts#L11)
+[core/shared/src/GlobalLogger.ts:11](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/GlobalLogger.ts#L11)

--- a/docs/ref/classes/shared_src.MemoryUsage.md
+++ b/docs/ref/classes/shared_src.MemoryUsage.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [shared/src](../modules/shared_src.md) / MemoryUsage
+[blok - v0.1.0](../README.md) / [shared/src](../modules/shared_src.md) / MemoryUsage
 
 # Class: MemoryUsage
 
@@ -52,7 +52,7 @@ MetricsBase.constructor
 
 #### Defined in
 
-[core/shared/src/utils/MemoryUsage.ts:9](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/utils/MemoryUsage.ts#L9)
+[core/shared/src/utils/MemoryUsage.ts:9](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/utils/MemoryUsage.ts#L9)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/utils/MemoryUsage.ts:7](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/utils/MemoryUsage.ts#L7)
+[core/shared/src/utils/MemoryUsage.ts:7](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/utils/MemoryUsage.ts#L7)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/utils/MemoryUsage.ts:6](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/utils/MemoryUsage.ts#L6)
+[core/shared/src/utils/MemoryUsage.ts:6](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/utils/MemoryUsage.ts#L6)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/utils/MemoryUsage.ts:8](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/utils/MemoryUsage.ts#L8)
+[core/shared/src/utils/MemoryUsage.ts:8](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/utils/MemoryUsage.ts#L8)
 
 ## Methods
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/utils/MemoryUsage.ts:36](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/utils/MemoryUsage.ts#L36)
+[core/shared/src/utils/MemoryUsage.ts:36](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/utils/MemoryUsage.ts#L36)
 
 ___
 
@@ -122,7 +122,7 @@ MetricsBase.getMetrics
 
 #### Defined in
 
-[core/shared/src/utils/MemoryUsage.ts:26](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/utils/MemoryUsage.ts#L26)
+[core/shared/src/utils/MemoryUsage.ts:26](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/utils/MemoryUsage.ts#L26)
 
 ___
 
@@ -140,7 +140,7 @@ MetricsBase.start
 
 #### Defined in
 
-[core/shared/src/utils/MemoryUsage.ts:11](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/utils/MemoryUsage.ts#L11)
+[core/shared/src/utils/MemoryUsage.ts:11](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/utils/MemoryUsage.ts#L11)
 
 ___
 
@@ -158,4 +158,4 @@ MetricsBase.stop
 
 #### Defined in
 
-[core/shared/src/utils/MemoryUsage.ts:24](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/utils/MemoryUsage.ts#L24)
+[core/shared/src/utils/MemoryUsage.ts:24](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/utils/MemoryUsage.ts#L24)

--- a/docs/ref/classes/shared_src.Metrics.md
+++ b/docs/ref/classes/shared_src.Metrics.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [shared/src](../modules/shared_src.md) / Metrics
+[blok - v0.1.0](../README.md) / [shared/src](../modules/shared_src.md) / Metrics
 
 # Class: Metrics
 
@@ -36,7 +36,7 @@
 
 #### Defined in
 
-[core/shared/src/Metrics.ts:10](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/Metrics.ts#L10)
+[core/shared/src/Metrics.ts:10](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/Metrics.ts#L10)
 
 ## Properties
 
@@ -46,7 +46,7 @@
 
 #### Defined in
 
-[core/shared/src/Metrics.ts:6](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/Metrics.ts#L6)
+[core/shared/src/Metrics.ts:6](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/Metrics.ts#L6)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/Metrics.ts:7](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/Metrics.ts#L7)
+[core/shared/src/Metrics.ts:7](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/Metrics.ts#L7)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/Metrics.ts:8](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/Metrics.ts#L8)
+[core/shared/src/Metrics.ts:8](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/Metrics.ts#L8)
 
 ## Methods
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/Metrics.ts:32](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/Metrics.ts#L32)
+[core/shared/src/Metrics.ts:32](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/Metrics.ts#L32)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/Metrics.ts:36](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/Metrics.ts#L36)
+[core/shared/src/Metrics.ts:36](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/Metrics.ts#L36)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/Metrics.ts:22](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/Metrics.ts#L22)
+[core/shared/src/Metrics.ts:22](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/Metrics.ts#L22)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/Metrics.ts:16](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/Metrics.ts#L16)
+[core/shared/src/Metrics.ts:16](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/Metrics.ts#L16)
 
 ___
 
@@ -136,4 +136,4 @@ ___
 
 #### Defined in
 
-[core/shared/src/Metrics.ts:26](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/Metrics.ts#L26)
+[core/shared/src/Metrics.ts:26](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/Metrics.ts#L26)

--- a/docs/ref/classes/shared_src.NodeBase.md
+++ b/docs/ref/classes/shared_src.NodeBase.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [shared/src](../modules/shared_src.md) / NodeBase
+[blok - v0.1.0](../README.md) / [shared/src](../modules/shared_src.md) / NodeBase
 
 # Class: NodeBase
 
@@ -50,7 +50,7 @@
 
 #### Defined in
 
-[core/shared/src/NodeBase.ts:17](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/NodeBase.ts#L17)
+[core/shared/src/NodeBase.ts:17](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/NodeBase.ts#L17)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/NodeBase.ts:16](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/NodeBase.ts#L16)
+[core/shared/src/NodeBase.ts:16](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/NodeBase.ts#L16)
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/NodeBase.ts:14](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/NodeBase.ts#L14)
+[core/shared/src/NodeBase.ts:14](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/NodeBase.ts#L14)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/NodeBase.ts:15](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/NodeBase.ts#L15)
+[core/shared/src/NodeBase.ts:15](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/NodeBase.ts#L15)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/NodeBase.ts:19](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/NodeBase.ts#L19)
+[core/shared/src/NodeBase.ts:19](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/NodeBase.ts#L19)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/NodeBase.ts:20](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/NodeBase.ts#L20)
+[core/shared/src/NodeBase.ts:20](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/NodeBase.ts#L20)
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/NodeBase.ts:18](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/NodeBase.ts#L18)
+[core/shared/src/NodeBase.ts:18](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/NodeBase.ts#L18)
 
 ## Methods
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/NodeBase.ts:88](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/NodeBase.ts#L88)
+[core/shared/src/NodeBase.ts:88](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/NodeBase.ts#L88)
 
 ___
 
@@ -153,7 +153,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/NodeBase.ts:84](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/NodeBase.ts#L84)
+[core/shared/src/NodeBase.ts:84](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/NodeBase.ts#L84)
 
 ___
 
@@ -174,7 +174,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/NodeBase.ts:22](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/NodeBase.ts#L22)
+[core/shared/src/NodeBase.ts:22](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/NodeBase.ts#L22)
 
 ___
 
@@ -194,7 +194,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/NodeBase.ts:41](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/NodeBase.ts#L41)
+[core/shared/src/NodeBase.ts:41](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/NodeBase.ts#L41)
 
 ___
 
@@ -214,7 +214,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/NodeBase.ts:62](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/NodeBase.ts#L62)
+[core/shared/src/NodeBase.ts:62](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/NodeBase.ts#L62)
 
 ___
 
@@ -238,7 +238,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/NodeBase.ts:69](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/NodeBase.ts#L69)
+[core/shared/src/NodeBase.ts:69](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/NodeBase.ts#L69)
 
 ___
 
@@ -259,7 +259,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/NodeBase.ts:64](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/NodeBase.ts#L64)
+[core/shared/src/NodeBase.ts:64](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/NodeBase.ts#L64)
 
 ___
 
@@ -279,7 +279,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/NodeBase.ts:101](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/NodeBase.ts#L101)
+[core/shared/src/NodeBase.ts:101](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/NodeBase.ts#L101)
 
 ___
 
@@ -300,4 +300,4 @@ ___
 
 #### Defined in
 
-[core/shared/src/NodeBase.ts:79](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/NodeBase.ts#L79)
+[core/shared/src/NodeBase.ts:79](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/NodeBase.ts#L79)

--- a/docs/ref/classes/shared_src.Trigger.md
+++ b/docs/ref/classes/shared_src.Trigger.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [shared/src](../modules/shared_src.md) / Trigger
+[blok - v0.1.0](../README.md) / [shared/src](../modules/shared_src.md) / Trigger
 
 # Class: Trigger
 
@@ -44,4 +44,4 @@ TriggerType.listen
 
 #### Defined in
 
-[core/shared/src/Trigger.ts:6](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/Trigger.ts#L6)
+[core/shared/src/Trigger.ts:6](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/Trigger.ts#L6)

--- a/docs/ref/interfaces/runner_src.INanoServiceResponse.md
+++ b/docs/ref/interfaces/runner_src.INanoServiceResponse.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / INanoServiceResponse
+[blok - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / INanoServiceResponse
 
 # Interface: INanoServiceResponse
 
@@ -28,4 +28,4 @@
 
 #### Defined in
 
-[core/runner/src/NanoServiceResponse.ts:5](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L5)
+[core/runner/src/NanoServiceResponse.ts:5](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/NanoServiceResponse.ts#L5)

--- a/docs/ref/interfaces/runner_src.JsonLikeObject.md
+++ b/docs/ref/interfaces/runner_src.JsonLikeObject.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / JsonLikeObject
+[blok - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / JsonLikeObject
 
 # Interface: JsonLikeObject
 

--- a/docs/ref/interfaces/runner_src.ParamsDictionary.md
+++ b/docs/ref/interfaces/runner_src.ParamsDictionary.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / ParamsDictionary
+[blok - v0.1.0](../README.md) / [runner/src](../modules/runner_src.md) / ParamsDictionary
 
 # Interface: ParamsDictionary
 

--- a/docs/ref/modules/runner_src.md
+++ b/docs/ref/modules/runner_src.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / runner/src
+[blok - v0.1.0](../README.md) / runner/src
 
 # Module: runner/src
 
@@ -62,7 +62,7 @@
 
 #### Defined in
 
-[core/runner/src/types/Average.ts:1](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/types/Average.ts#L1)
+[core/runner/src/types/Average.ts:1](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/types/Average.ts#L1)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/types/Condition.ts:3](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/types/Condition.ts#L3)
+[core/runner/src/types/Condition.ts:3](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/types/Condition.ts#L3)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/types/Conditions.ts:3](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/types/Conditions.ts#L3)
+[core/runner/src/types/Conditions.ts:3](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/types/Conditions.ts#L3)
 
 ___
 
@@ -117,7 +117,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/types/Config.ts:6](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/types/Config.ts#L6)
+[core/runner/src/types/Config.ts:6](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/types/Config.ts#L6)
 
 ___
 
@@ -133,7 +133,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/types/Flow.ts:3](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/types/Flow.ts#L3)
+[core/runner/src/types/Flow.ts:3](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/types/Flow.ts#L3)
 
 ___
 
@@ -150,7 +150,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/types/GlobalOptions.ts:4](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/types/GlobalOptions.ts#L4)
+[core/runner/src/types/GlobalOptions.ts:4](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/types/GlobalOptions.ts#L4)
 
 ___
 
@@ -166,7 +166,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/types/Inputs.ts:3](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/types/Inputs.ts#L3)
+[core/runner/src/types/Inputs.ts:3](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/types/Inputs.ts#L3)
 
 ___
 
@@ -180,7 +180,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/types/Node.ts:8](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/types/Node.ts#L8)
+[core/runner/src/types/Node.ts:8](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/types/Node.ts#L8)
 
 ___
 
@@ -196,7 +196,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/types/Properties.ts:3](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/types/Properties.ts#L3)
+[core/runner/src/types/Properties.ts:3](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/types/Properties.ts#L3)
 
 ___
 
@@ -210,7 +210,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/types/Targets.ts:3](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/types/Targets.ts#L3)
+[core/runner/src/types/Targets.ts:3](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/types/Targets.ts#L3)
 
 ___
 
@@ -224,7 +224,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/types/Trigger.ts:3](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/types/Trigger.ts#L3)
+[core/runner/src/types/Trigger.ts:3](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/types/Trigger.ts#L3)
 
 ___
 
@@ -243,7 +243,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/types/TriggerHttp.ts:1](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/types/TriggerHttp.ts#L1)
+[core/runner/src/types/TriggerHttp.ts:1](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/types/TriggerHttp.ts#L1)
 
 ___
 
@@ -260,7 +260,7 @@ ___
 
 #### Defined in
 
-[core/runner/src/types/TriggerResponse.ts:3](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/types/TriggerResponse.ts#L3)
+[core/runner/src/types/TriggerResponse.ts:3](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/types/TriggerResponse.ts#L3)
 
 ___
 
@@ -274,4 +274,4 @@ ___
 
 #### Defined in
 
-[core/runner/src/types/Triggers.ts:3](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/runner/src/types/Triggers.ts#L3)
+[core/runner/src/types/Triggers.ts:3](https://github.com/deskree-inc/blok/blob/fd59582/core/runner/src/types/Triggers.ts#L3)

--- a/docs/ref/modules/shared_src.md
+++ b/docs/ref/modules/shared_src.md
@@ -1,4 +1,4 @@
-[nanoservice-ts - v0.1.0](../README.md) / shared/src
+[blok - v0.1.0](../README.md) / shared/src
 
 # Module: shared/src
 
@@ -40,7 +40,7 @@
 
 #### Defined in
 
-[core/shared/src/types/ConfigContext.ts:3](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/types/ConfigContext.ts#L3)
+[core/shared/src/types/ConfigContext.ts:3](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/types/ConfigContext.ts#L3)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/types/Context.ts:11](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/types/Context.ts#L11)
+[core/shared/src/types/Context.ts:11](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/types/Context.ts#L11)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/types/ErrorContext.ts:3](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/types/ErrorContext.ts#L3)
+[core/shared/src/types/ErrorContext.ts:3](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/types/ErrorContext.ts#L3)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/types/FunctionContext.ts:1](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/types/FunctionContext.ts#L1)
+[core/shared/src/types/FunctionContext.ts:1](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/types/FunctionContext.ts#L1)
 
 ___
 
@@ -123,7 +123,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/types/LoggerContext.ts:1](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/types/LoggerContext.ts#L1)
+[core/shared/src/types/LoggerContext.ts:1](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/types/LoggerContext.ts#L1)
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/Metrics.ts:49](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/Metrics.ts#L49)
+[core/shared/src/Metrics.ts:49](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/Metrics.ts#L49)
 
 ___
 
@@ -155,7 +155,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/types/NodeConfigContext.ts:3](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/types/NodeConfigContext.ts#L3)
+[core/shared/src/types/NodeConfigContext.ts:3](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/types/NodeConfigContext.ts#L3)
 
 ___
 
@@ -169,7 +169,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/types/RequestContext.ts:3](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/types/RequestContext.ts#L3)
+[core/shared/src/types/RequestContext.ts:3](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/types/RequestContext.ts#L3)
 
 ___
 
@@ -188,7 +188,7 @@ ___
 
 #### Defined in
 
-[core/shared/src/types/ResponseContext.ts:3](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/types/ResponseContext.ts#L3)
+[core/shared/src/types/ResponseContext.ts:3](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/types/ResponseContext.ts#L3)
 
 ___
 
@@ -209,4 +209,4 @@ ___
 
 #### Defined in
 
-[core/shared/src/types/Step.ts:3](https://github.com/deskree-inc/nanoservice-ts/blob/fd59582/core/shared/src/types/Step.ts#L3)
+[core/shared/src/types/Step.ts:3](https://github.com/deskree-inc/blok/blob/fd59582/core/shared/src/types/Step.ts#L3)

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
 	"engines": {
 		"pnpm": ">=10.2.0"
 	},
-	"packageManager": "pnpm@10.4.1",
+	"packageManager": "pnpm@10.11.1",
 	"private": true
 }

--- a/packages/cli/src/commands/create/node.ts
+++ b/packages/cli/src/commands/create/node.ts
@@ -13,7 +13,7 @@ import { python3_file } from "./utils/Examples.js";
 const exec = util.promisify(child_process.exec);
 
 const HOME_DIR = `${os.homedir()}/.nanoctl`;
-const GITHUB_REPO_LOCAL = `${HOME_DIR}/nanoservice-ts`;
+const GITHUB_REPO_LOCAL = `${HOME_DIR}/blok`;
 
 export async function createNode(opts: OptionValues, currentPath = false) {
 	const availableManagers = await pm.getAvailableManagers();
@@ -27,7 +27,7 @@ export async function createNode(opts: OptionValues, currentPath = false) {
 
 	if (!isDefault) {
 		console.log(
-			figlet.textSync("nanoservice-ts CLI".toUpperCase(), {
+			figlet.textSync("Blok CLI".toUpperCase(), {
 				font: "Digital",
 				horizontalLayout: "default",
 				verticalLayout: "default",

--- a/packages/cli/src/commands/create/project.ts
+++ b/packages/cli/src/commands/create/project.ts
@@ -22,8 +22,8 @@ import {
 const exec = util.promisify(child_process.exec);
 
 const HOME_DIR = `${os.homedir()}/.nanoctl`;
-const GITHUB_REPO_LOCAL = `${HOME_DIR}/nanoservice-ts`;
-const GITHUB_REPO_REMOTE = "https://github.com/deskree-inc/nanoservice-ts.git";
+const GITHUB_REPO_LOCAL = `${HOME_DIR}/blok`;
+const GITHUB_REPO_REMOTE = "https://github.com/deskree-inc/blok.git";
 
 fsExtra.ensureDirSync(HOME_DIR);
 const options: Partial<SimpleGitOptions> = {

--- a/packages/cli/src/commands/create/workflow.ts
+++ b/packages/cli/src/commands/create/workflow.ts
@@ -8,7 +8,7 @@ import color from "picocolors";
 import { workflow_template } from "./utils/Examples.js";
 
 const HOME_DIR = `${os.homedir()}/.nanoctl`;
-const GITHUB_REPO_LOCAL = `${HOME_DIR}/nanoservice-ts`;
+const GITHUB_REPO_LOCAL = `${HOME_DIR}/blok`;
 
 export async function createWorkflow(opts: OptionValues, currentPath = false) {
 	const isDefault = opts.name !== undefined;

--- a/packages/cli/src/commands/generate/NodeFileWriter.ts
+++ b/packages/cli/src/commands/generate/NodeFileWriter.ts
@@ -115,7 +115,7 @@ export default class NodeFileWriter {
 			const dirPath = process.cwd();
 			const nodeDir = `${dirPath}/src/nodes`;
 			const HOME_DIR = `${os.homedir()}/.nanoctl`;
-			const GITHUB_REPO_LOCAL = `${HOME_DIR}/nanoservice-ts`;
+			const GITHUB_REPO_LOCAL = `${HOME_DIR}/blok`;
 
 			// Check if the nodes directory exists, if not, create it
 			if (!fs.existsSync(nodeDir)) {

--- a/triggers/grpc/package.json
+++ b/triggers/grpc/package.json
@@ -7,7 +7,7 @@
 	},
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"repository": "https://github.com/deskree-inc/nanoservice-ts.git",
+	"repository": "https://github.com/deskree-inc/blok.git",
 	"author": "Marco A. Castillo Della Sera",
 	"license": "Apache-2.0",
 	"scripts": {

--- a/triggers/http/notes/CLI_Commands/Building.md
+++ b/triggers/http/notes/CLI_Commands/Building.md
@@ -25,7 +25,7 @@ npx nanoctl build [options]
   ### Options
   | Option       | Alias | Type    | Description                | Default            |
   |--------------|-------|---------|----------------------------|--------------------|
-  | `--directory`| `-d`  | string  | Source directory path      | `./nanoservice-ts` |
+  | `--directory`| `-d`  | string  | Source directory path      | `./blok` |
   | `--help`     | `-h`  | boolean | Show help                  | `false`            |
  
   ### Commands


### PR DESCRIPTION
Updates documentation and configuration files to reflect the project name change from Nanoservice to Blok.

This includes updates to:
- Contribution guidelines
- README
- Security policy
- Various documentation sections

Ensuring consistency in URLs and terminology throughout the codebase.